### PR TITLE
Fix deprecation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.5
-  - 2.3.3
-  - 2.4.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 addons:
   postgresql: '9.4'
 before_install:

--- a/lib/jsonb_accessor/query_builder.rb
+++ b/lib/jsonb_accessor/query_builder.rb
@@ -81,7 +81,7 @@ module JsonbAccessor
         JsonbAccessor::QueryHelper.validate_column_name!(all, column_name)
         JsonbAccessor::QueryHelper.validate_field_name!(all, column_name, field_name)
         JsonbAccessor::QueryHelper.validate_direction!(direction)
-        order("(#{table_name}.#{column_name} -> '#{field_name}') #{direction}")
+        order(Arel.sql("(#{table_name}.#{column_name} -> '#{field_name}') #{direction}"))
       end)
     end
   end


### PR DESCRIPTION
Raw sql should be wrapped by `Arel.sql(...)`. This will be standard in ActiveRecord 6.x.