### PR TITLE
Fix rubocop error

### DIFF
--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -49,11 +49,14 @@ module JsonbAccessor
         # Fields may have procs as default value. This means `all_defaults_mapping` may contain procs as values. To make this work
         # with the attributes API, we need to wrap `all_defaults_mapping` with a proc itself, making sure it returns a plain hash
         # each time it is evaluated.
-        all_defaults_mapping_proc =
-          if all_defaults_mapping.present?
-            -> { all_defaults_mapping.map { |key, value| [key, value.respond_to?(:call) ? value.call : value] }.to_h }
-          end
-        attribute jsonb_attribute, :jsonb, default: all_defaults_mapping_proc if all_defaults_mapping_proc.present?
+        if all_defaults_mapping.present?
+          attribute jsonb_attribute, :jsonb, default: proc {
+            all_defaults_mapping.map do |key, value|
+              value = value.call if value.respond_to?(:call)
+              [key, value]
+            end.to_h
+          }
+        end
 
         # Setters are in a module to allow users to override them and still be able to use `super`.
         setters = Module.new do


### PR DESCRIPTION
There was a Rubocop error here that was halting all spec tests after it. 