### PR TITLE
Remove standalone_migrations gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,10 +5,25 @@ require "bundler/setup"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
-require "standalone_migrations"
-StandaloneMigrations::Tasks.load_tasks
 
 RSpec::Core::RakeTask.new
 RuboCop::RakeTask.new
+
+require 'active_record'
+include ActiveRecord::Tasks
+
+root = File.expand_path '..', __FILE__
+DatabaseTasks.env = ENV['ENV'] || 'development'
+DatabaseTasks.database_configuration = YAML.load(File.read(File.join(root, 'db/config.yml')))
+DatabaseTasks.db_dir = File.join root, 'db'
+DatabaseTasks.migrations_paths = [File.join(root, 'db/migrate')]
+DatabaseTasks.root = root
+
+task :environment do
+  ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
+  ActiveRecord::Base.establish_connection DatabaseTasks.env.to_sym
+end
+
+load 'active_record/railties/databases.rake'
 
 task(default: %i[rubocop spec])

--- a/jsonb_accessor.gemspec
+++ b/jsonb_accessor.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.6.0"
   spec.add_development_dependency "rubocop", "~> 0.48.1"
-  spec.add_development_dependency "standalone_migrations", "~> 5.2.0"
 end


### PR DESCRIPTION
This will remove the standalone_migrations gem from
the modules dependencies and creates the rake tasks
for db itself using activerecord.

The standalone_migrations gem did not yet add support
for activerecord >5.2 and blocks rails 6 support.