### PR TITLE
Fix performance issues with how jsonb_accessor clears dirty tracking

### DIFF
--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -88,9 +88,11 @@ module JsonbAccessor
             jsonb_values = public_send(jsonb_attribute) || {}
             jsonb_values.each do |store_key, value|
               name = names_and_store_keys.key(store_key)
-              write_attribute(name, value) if name
+              next unless name
+
+              write_attribute(name, value)
+              clear_attribute_change(name) if persisted?
             end
-            clear_changes_information if persisted?
           end
         end
 

--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -288,6 +288,7 @@ RSpec.describe JsonbAccessor do
       expect(persisted_instance).to_not be_foo_changed
       expect(persisted_instance).to_not be_bar_changed
       expect(persisted_instance).to_not be_options_changed
+      expect(persisted_instance.changes).to be_empty
 
       persisted_instance = klass.find(klass.create!(foo: "foo", bar: "bar").id)
       expect(persisted_instance.foo).to eq("foo")


### PR DESCRIPTION
Closes #120

Previously, the jsonb_accessor after_init callback
would clear ALL of the models' attributes, and not
just the jsonb_accessor attributes. This had the
effect of forcefully deserializing and then
immediately reserializing ALL of the models'
attributes, which was causing a massive performance
hit on our app on a model that uses the `serialize`
API on another attribute.

This change makes sure to only reset the dirty-tracking
on the jsonb_accessor attributes.

### Benchmarks

My app has a Purchase model with its own jsonb_accessor as well as one included in a concern. This is what I was seeing when I called `Purchase.find(id)`

![image](https://user-images.githubusercontent.com/81818/79993673-00f72300-8483-11ea-8219-631429fd90ca.png)

There's a forced deserialize/serialize called for each jsonb_accessor declaration. Normally the `serialize`/`attribute` APIs are lazy and don't deserialize unless you access them.

#### With this commit

When I re-ran the benchmarks with this commit, `Purchase.find` got a 20x performance boost. Flame chart is now entire the `Purchase.find` with lazy deserialization semantics:

![image](https://user-images.githubusercontent.com/81818/79994178-9db9c080-8483-11ea-8c75-15a7b90c5955.png)

I also tested performance when accessing the serialized attr (`.cart_line_items`); the performance improvement was 3x (320%), and the flame chart looked like this:

![image](https://user-images.githubusercontent.com/81818/79994484-099c2900-8484-11ea-8969-d0a4da70db3b.png)


