### PR TITLE
update Rake version per Dependabot alert

### DIFF
--- a/jsonb_accessor.gemspec
+++ b/jsonb_accessor.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-doc"
   spec.add_development_dependency "pry-nav"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.6.0"
   spec.add_development_dependency "rubocop", "~> 0.48.1"
   spec.add_development_dependency "standalone_migrations", "~> 5.2.0"


### PR DESCRIPTION
The old version of Rake had a security vulnerability--upgraded to get the patch!