### PR TITLE
Fix keyword param deprecation warning in Ruby 2.7

### DIFF
--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -11,16 +11,11 @@ module JsonbAccessor
 
         # Defines virtual attributes for each jsonb field.
         field_types.each do |name, type|
-          if type.is_a?(Array)
-            if type.last.is_a?(Hash)
-              *args, keyword_args = type
-              attribute name, *args, **keyword_args
-            else
-              attribute name, *type
-            end
-          else
-            attribute name, type
-          end
+          next attribute name, type unless type.is_a?(Array)
+          next attribute name, *type unless type.last.is_a?(Hash)
+
+          *args, keyword_args = type
+          attribute name, *args, **keyword_args
         end
 
         store_key_mapping_method_name = "jsonb_store_key_mapping_for_#{jsonb_attribute}"

--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -11,7 +11,16 @@ module JsonbAccessor
 
         # Defines virtual attributes for each jsonb field.
         field_types.each do |name, type|
-          attribute name, *type
+          if type.is_a?(Array)
+            if type.last.is_a?(Hash)
+              *args, keyword_args = type
+              attribute name, *args, **keyword_args
+            else
+              attribute name, *type
+            end
+          else
+            attribute name, type
+          end
         end
 
         store_key_mapping_method_name = "jsonb_store_key_mapping_for_#{jsonb_attribute}"


### PR DESCRIPTION
Hi thanks for this great gem.

This change prepares it for Ruby 2.8 / 3.0. Fixes #125 .

Right now with Ruby 2.7 you get the following warning:

`.....lib/jsonb_accessor/macro.rb:14: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`

This happens when using something like this

```ruby
jsonb_accessor :data, title: [:string, default: "Untitled"]
# last argument to title is a hash
```

This expands to `attribute :title, :string, { default: "Untitled" }` which will raise an error in the next Ruby version as the last argument is missing the double splash `**`.

More info here: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/