### PR TITLE
1.1.0 is out but the doc still recommends ~> 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It also adds generic scopes for querying `jsonb` columns.
 Add this line to your application's `Gemfile`:
 
 ```ruby
-gem "jsonb_accessor", "~> 1.0.0"
+gem "jsonb_accessor", "~> 1"
 ```
 
 And then execute:


### PR DESCRIPTION
1.1.0 was released, but the README still recommends ~> 1.0.0. This prevented me from noticing there was a new version for a while.

`~> 1` seems reasonable to keep it within the major version.