### PR TITLE
Allow arbitrary data to be written to JSON field

### DIFF
--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -84,6 +84,10 @@ module JsonbAccessor
 
             empty_named_attributes = names_to_store_keys.transform_values { nil }
             empty_named_attributes.merge(value_with_named_keys).each do |name, attribute_value|
+              # Undefined keys: There might be things in the JSON that haven't been defined using jsonb_accessor
+              # It should still be possible to save arbitrary data in the JSON
+              next unless has_attribute? name
+
               write_attribute(name, attribute_value)
             end
           end

--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -561,4 +561,22 @@ RSpec.describe JsonbAccessor do
       end
     end
   end
+
+  describe "arbitrary data" do
+    let(:field) { "external" }
+    let(:some_value) { ["any", "value", { "really" => "actually" }] }
+
+    it "is possible to set arbitrary data" do
+      options = instance.options.merge(field => some_value)
+      instance.update!(options: options)
+      expect(instance.options[field]).to eq some_value
+
+      # make sure it doesn't get lost after normal use
+      instance.foo = "fooos"
+      instance.save!
+      instance.reload
+      expect(instance.foo).to eq "fooos"
+      expect(instance.options[field]).to eq some_value
+    end
+  end
 end


### PR DESCRIPTION
Closes #100 

You can now store any data in the JSON and use fields not defined by `jsonb_accessor`. This allows for a more flexible use of the gem.