### PR TITLE
Upgrade checkout action to avoid Node v12 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -130,7 +130,7 @@ jobs:
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
On May 18th Node v12 actions will stop working, so addressing this has become more urgent.