### PR TITLE
Add Rails true enum support

### DIFF
--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -66,7 +66,9 @@ module JsonbAccessor
             define_method("#{name}=") do |value|
               super(value)
 
-              attribute_value = public_send(name)
+              # If enum was defined, take the value from the enum and not what comes out directly from the getter
+              attribute_value = defined_enums[name].present? ? defined_enums[name][value] : public_send(name)
+
               # Rails always saves time based on `default_timezone`. Since #as_json considers timezone, manual conversion is needed
               if attribute_value.acts_like?(:time)
                 attribute_value = (JsonbAccessor::Helpers.active_record_default_timezone == :utc ? attribute_value.utc : attribute_value.in_time_zone).strftime("%F %R:%S.%L")

--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -17,9 +17,12 @@ RSpec.describe JsonbAccessor do
     build_class(
       foo: :string,
       bar: :integer,
+      ban: :integer,
       baz: [:integer, { array: true }],
       bazzle: [:integer, { default: 5 }]
-    )
+    ) do
+      enum ban: { foo: 1, bar: 2 }
+    end
   end
   let(:instance) { klass.new }
 
@@ -57,6 +60,12 @@ RSpec.describe JsonbAccessor do
 
     it "supports defaults" do
       expect(instance.bazzle).to eq(5)
+    end
+
+    it "supports enums" do
+      instance.ban = :foo
+      expect(instance.ban).to eq("foo")
+      expect(instance.options["ban"]).to eq(1)
     end
 
     it "initializes without the jsonb_accessor field selected" do


### PR DESCRIPTION
I first found [this thread](https://github.com/madeintandem/jsonb_accessor/issues/87) and gave Rails enum a shot. It "seemed" to work, but it only did for `String` mappings. Even if `enum` was defined, when assigning attributes, `jsonb_accessor` would update the jsonb with the value from the public getter, which returns the corresponding enum key (whatever that is) and not the actual value that should be stored in the database.

This was first noticed by [kg-currenxie](https://github.com/kg-currenxie).

### Example

Given:
```
jsonb_accessor :data, my_enum_attribute: :integer
enum my_enum_attribute: { "Foo" => 1, "Bar" => 2 }
```

`MyClass.create(my_enum_attribute: "Foo")` will store a jsonb with `"Foo"` as value instead of `1`.

With the introduced changes, the actual value stored will be `1`.

The use of enums with integers allows a ton of flexibility when it comes to altering existing enum keys. I'm in the middle of a migration and having enums defined with integers instead of strings makes things much easier.