### PR TITLE
Fix errors when loading array of datetime

### DIFF
--- a/db/config.yml
+++ b/db/config.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   database: jsonb_accessor
   host: <%= ENV.fetch("DATABASE_HOST") { "127.0.0.1" } %>
-  user: postgres
+  username: <%= ENV.fetch("DATABASE_USER") { "postgres" } %>
 
 test:
   <<: *default

--- a/lib/jsonb_accessor/helpers.rb
+++ b/lib/jsonb_accessor/helpers.rb
@@ -24,14 +24,23 @@ module JsonbAccessor
       return value if value.blank?
 
       if attribute_type == :datetime
-        value = if active_record_default_timezone == :utc
-                  Time.find_zone("UTC").parse(value).in_time_zone
+        value = if value.is_a?(Array)
+                  value.map { |v| parse_date(v) }
                 else
-                  Time.zone.parse(value)
+                  parse_date(value)
                 end
       end
 
       value
+    end
+
+    # Parse datetime based on the configured default_timezone
+    def parse_date(datetime)
+      if active_record_default_timezone == :utc
+        Time.find_zone("UTC").parse(datetime).in_time_zone
+      else
+        Time.zone.parse(datetime)
+      end
     end
   end
 end

--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe JsonbAccessor do
       bar: :integer,
       ban: :integer,
       baz: [:integer, { array: true }],
-      bazzle: [:integer, { default: 5 }]
+      bazzle: [:integer, { default: 5 }],
+      dates: [:datetime, { array: true }]
     ) do
       enum ban: { foo: 1, bar: 2 }
     end
@@ -56,6 +57,17 @@ RSpec.describe JsonbAccessor do
     it "supports arrays" do
       instance.baz = %w[1 2 3]
       expect(instance.baz).to eq([1, 2, 3])
+    end
+
+    it "supports array of date" do
+      # Write
+      instance.dates = [Date.new(2017, 1, 1), Date.new(2017, 1, 2)]
+      expect { instance.save! }.to_not raise_error
+      # Read
+      instance.reload
+
+      expect(instance.dates).to be_kind_of Array
+      expect(instance.dates.first).to be_kind_of Time
     end
 
     it "supports defaults" do


### PR DESCRIPTION
When we are upgrading to rails 7.0.8 from rails 6.0. Somehow it breaks:
```
jsonb_attributes dates: [:datetime, array: true]
```